### PR TITLE
[uniconfig] Fix init-container host name

### DIFF
--- a/charts/uniconfig/Chart.yaml
+++ b/charts/uniconfig/Chart.yaml
@@ -13,3 +13,10 @@ maintainers:
   - name: FRINX
 icon: https://avatars.githubusercontent.com/u/23452093?s=200&v=4
 appVersion: "4.2.10"
+annotations:
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Fix DB host variable when it is different from the default
+      links:
+        - name: GitHub PR
+          url: https://github.com/FRINXio/helm-charts/pull/14

--- a/charts/uniconfig/Chart.yaml
+++ b/charts/uniconfig/Chart.yaml
@@ -16,7 +16,7 @@ appVersion: "4.2.10"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix DB host variable when it is different from the default
+      description: Fix DB hostname in initContainer if it is different from the default
       links:
         - name: GitHub PR
           url: https://github.com/FRINXio/helm-charts/pull/14

--- a/charts/uniconfig/Chart.yaml
+++ b/charts/uniconfig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: uniconfig
-version: 1.0.0
+version: 1.0.1
 description: A Helm chart for UniConfig Kubernetes deployment
 type: application
 home: https://github.com/FRINXio/helm-charts

--- a/charts/uniconfig/templates/deployment.yaml
+++ b/charts/uniconfig/templates/deployment.yaml
@@ -36,11 +36,19 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
+      {{ if .Values.dbPersistence.connection_databaseLocations_host }}
+        - name: check-db-ready
+          image: postgres:alpine
+          command: ['sh', '-c',
+            "until pg_isready -h {{ .Values.dbPersistence.connection_databaseLocations_host }} -p 5432;
+            do echo waiting for database; sleep 2; done;"]
+      {{ else }}
         - name: check-db-ready
           image: postgres:alpine
           command: ['sh', '-c',
             "until pg_isready -h {{ .Release.Name }}-postgresql -p 5432;
             do echo waiting for database; sleep 2; done;"]
+      {{ end }}      
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -71,7 +79,7 @@ spec:
               value: {{ .Values.dbPersistence.connection_username }}
             - name: dbPersistence_connection_password
               value: {{ .Values.dbPersistence.connection_password }}
-              {{ if .Values.postgresql.enabled }}
+              {{- if and (eq .Values.postgresql.enabled true) (not .Values.dbPersistence.connection_databaseLocations_host) }}
             - name: dbPersistence_connection_databaseLocations_host
               value: "{{ .Release.Name }}-postgresql"
               {{ else }}

--- a/charts/uniconfig/values.yaml
+++ b/charts/uniconfig/values.yaml
@@ -86,7 +86,7 @@ dbPersistence:
   connection_dbName: "uniconfig"
   connection_username: "postgresU"
   connection_password: "postgresP"
-  connection_databaseLocations_host: "uniconfig-postgres-postgresql"
+  connection_databaseLocations_host: ""
   connection_databaseLocations_port: "5432"
 
 azure:


### PR DESCRIPTION
- this PR fix scenario where we use dependency postgresql but we use different service name for it

Signed-off-by: Simon Misencik <simon.misencik@gmail.com>


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[krakend]`)
- [x] Update chart release notes *[annotation](https://artifacthub.io/docs/topics/annotations/helm/)*
