### PR TITLE
[frinx-frontend] Increased initialDelaySeconds for graphql-proxy liveness and readiness container

### DIFF
--- a/charts/frinx-frontend/Chart.yaml
+++ b/charts/frinx-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: frinx-frontend
 description: A Helm chart for Kubernetes deployment of the Frinx UI
 icon: https://avatars.githubusercontent.com/u/23452093?s=200&v=4
 type: application
-version: 4.0.0
+version: 4.0.1
 appVersion: "6.0.0"
 maintainers:
   - name: FRINX
@@ -14,13 +14,8 @@ annotations:
     - name: frinx-graphql-proxy
       image: frinx/frinx-graphql-proxy:6.0.0
   artifacthub.io/changes: |
-    - kind: changed
-      description: Changed ingress configuration
+    - kind: fixed
+      description: Increased initialDelaySeconds for graphql-proxy liveness and readiness container
       links:
         - name: GitHub PR
-          url: https://github.com/FRINXio/helm-charts/pull/345
-    - kind: added
-      description: Frinx Graphql Proxy setup
-      links:
-        - name: GitHub PR
-          url: https://github.com/FRINXio/helm-charts/pull/345
+          url: https://github.com/FRINXio/helm-charts/pull/369

--- a/charts/frinx-frontend/templates/deployment.yaml
+++ b/charts/frinx-frontend/templates/deployment.yaml
@@ -78,10 +78,12 @@ spec:
             httpGet:
               path: /health
               port: 5555
+            initialDelaySeconds: 15
           readinessProbe:
             httpGet:
               path: /health
               port: 5555
+            initialDelaySeconds: 15
           resources:
             {{- toYaml .Values.proxyResources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[krakend]`)
- [ ] Update the documentation if a new value has been added
- [ ] Update chart release notes *[annotation](https://artifacthub.io/docs/topics/annotations/helm/)*
